### PR TITLE
Update the way copilot edit is started

### DIFF
--- a/content/1-hour/4-add-feature.md
+++ b/content/1-hour/4-add-feature.md
@@ -30,7 +30,8 @@ Adding the filters to the page will require updating a minimum of two files - th
 6. If available, select **Claude 3.5 Sonnet** from the list of available models
 7. Select **Add Context...** in the chat window.
 8. Select **server/app.py** and **client/src/components/DogList.svelte** files (you need to select **Add context** for each file) 
-  - **Hint**: if you type the file names, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
+> [!TIP]
+> If you type the file names after clicking **Add context**, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
 9. Ask Copilot to generate the update you want to the page, which is to add filters for both dog breed and if dogs are available for adoption. Use your own phrasing, ensuring the following requirements are met:
     - A dropdown list should be provided with all breeds
     - A checkbox should be available to only show available dogs

--- a/content/1-hour/4-add-feature.md
+++ b/content/1-hour/4-add-feature.md
@@ -25,14 +25,13 @@ Adding the filters to the page will require updating a minimum of two files - th
 1. Return to your IDE with your project open.
 2. Close any tabs you have open inside your IDE.
 3. Enable Auto Save by selecting **File** > **Auto Save**.
-4. Open the following files in your IDE (which we'll point Copilot chat to for context):
-   - **server/app.py**
-   - **client/src/components/DogList.svelte** 
-5. Select **Copilot Edits** in the Copilot Chat window.
-6. If available, select **Claude 3.5 Sonnet** from the list of available models.
+4. Open GitHub Copilot Chat.
+5. Switch to edit mode by selecting **Edit** in the chat mode dropdown at the bottom of Chat view (should be currently **Ask**)
+6. If available, select **Claude 3.5 Sonnet** from the list of available models
 7. Select **Add Context...** in the chat window.
-7. Select **Open Editors** from the prompt. This will add all currently open files to the context.
-8. Ask Copilot to generate the update you want to the page, which is to add filters for both dog breed and if dogs are available for adoption. Use your own phrasing, ensuring the following requirements are met:
+8. Select **server/app.py** and **client/src/components/DogList.svelte** files (you need select **Add context** for each file) 
+  - **Hint**: if you type the file names, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
+9. Ask Copilot to generate the update you want to the page, which is to add filters for both dog breed and if dogs are available for adoption. Use your own phrasing, ensuring the following requirements are met:
     - A dropdown list should be provided with all breeds
     - A checkbox should be available to only show available dogs
     - The page should automatically refresh whenever a change is made

--- a/content/1-hour/4-add-feature.md
+++ b/content/1-hour/4-add-feature.md
@@ -29,7 +29,7 @@ Adding the filters to the page will require updating a minimum of two files - th
 5. Switch to edit mode by selecting **Edit** in the chat mode dropdown at the bottom of Chat view (should be currently **Ask**)
 6. If available, select **Claude 3.5 Sonnet** from the list of available models
 7. Select **Add Context...** in the chat window.
-8. Select **server/app.py** and **client/src/components/DogList.svelte** files (you need select **Add context** for each file) 
+8. Select **server/app.py** and **client/src/components/DogList.svelte** files (you need to select **Add context** for each file) 
   - **Hint**: if you type the file names, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
 9. Ask Copilot to generate the update you want to the page, which is to add filters for both dog breed and if dogs are available for adoption. Use your own phrasing, ensuring the following requirements are met:
     - A dropdown list should be provided with all breeds

--- a/content/full-day/6-code.md
+++ b/content/full-day/6-code.md
@@ -82,7 +82,7 @@ Adding the filters to the page will require updating a minimum of three files - 
 3. Switch to edit mode by selecting **Edit** in the chat mode dropdown at the bottom of Chat view (should be currently **Ask**)
 4. Ensure **Claude 3.7 Sonnet** is selected for the model.
 5. Select **Add Context...** in the chat window.
-6. Select **server/app.py**, **client/src/components/DogList.svelte** and **server/test_app.py** files (you need select **Add context** for each file) 
+6. Select **server/app.py**, **client/src/components/DogList.svelte** and **server/test_app.py** files (you need to select **Add context** for each file) 
   - **Hint**: if you type the file names, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
 
 7. Ask Copilot to perform the operation you want, to update the page to add the filters. It should meet the following requirements:

--- a/content/full-day/6-code.md
+++ b/content/full-day/6-code.md
@@ -80,7 +80,7 @@ Adding the filters to the page will require updating a minimum of three files - 
    - **client/src/components/DogList.svelte** 
 2. Open GitHub Copilot Chat.
 3. Switch to edit mode by selecting **Edit** in the chat mode dropdown at the bottom of Chat view (should be currently **Ask**)
-4. Ensure **Claude 3.7 Sonnet** is selected for the model.
+4. If available, select **Claude 3.7 Sonnet** for the model.
 5. Select **Add Context...** in the chat window.
 6. Select **server/app.py**, **client/src/components/DogList.svelte** and **server/test_app.py** files (you need to select **Add context** for each file) 
   - **Hint**: if you type the file names, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)

--- a/content/full-day/6-code.md
+++ b/content/full-day/6-code.md
@@ -82,9 +82,9 @@ Adding the filters to the page will require updating a minimum of three files - 
 3. Switch to edit mode by selecting **Edit** in the chat mode dropdown at the bottom of Chat view (should be currently **Ask**)
 4. If available, select **Claude 3.7 Sonnet** for the model.
 5. Select **Add Context...** in the chat window.
-6. Select **server/app.py**, **client/src/components/DogList.svelte** and **server/test_app.py** files (you need to select **Add context** for each file) 
-  - **Hint**: if you type the file names, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
-
+6. Select **server/app.py**, **client/src/components/DogList.svelte** and **server/test_app.py** files (you need to select **Add context** for each file)
+> [!TIP]
+> If you type the file names after clicking **Add context**, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
 7. Ask Copilot to perform the operation you want, to update the page to add the filters. It should meet the following requirements:
     - A dropdown list should be provided with all breeds
     - A checkbox should be available to only show available dogs

--- a/content/full-day/6-code.md
+++ b/content/full-day/6-code.md
@@ -78,18 +78,22 @@ Adding the filters to the page will require updating a minimum of three files - 
    - **server/app.py**
    - **server/test_app.py**
    - **client/src/components/DogList.svelte** 
-2. Select **Copilot Edits** in the Copilot Chat window.
-3. Ensure **Claude 3.7 Sonnet** is selected for the model.
-4. Select **Add Context...** in the chat window and **Open Editors** from the prompt. This will add all currently open files to the context.
-5. Ask Copilot to perform the operation you want, to update the page to add the filters. It should meet the following requirements:
+2. Open GitHub Copilot Chat.
+3. Switch to edit mode by selecting **Edit** in the chat mode dropdown at the bottom of Chat view (should be currently **Ask**)
+4. Ensure **Claude 3.7 Sonnet** is selected for the model.
+5. Select **Add Context...** in the chat window.
+6. Select **server/app.py**, **client/src/components/DogList.svelte** and **server/test_app.py** files (you need select **Add context** for each file) 
+  - **Hint**: if you type the file names, they will show up in the filter. You can also drag the files or right click file in explorer and select `Copilot -> Add File to Chat`)
+
+7. Ask Copilot to perform the operation you want, to update the page to add the filters. It should meet the following requirements:
     - A dropdown list should be provided with all breeds
     - A checkbox should be available to only show available dogs
     - The page should automatically refresh whenever a change is made
     - Tests should be updated for any changes to the endpoint.
-6. Review the code suggestions to ensure they behave the way you expect them to, making any necessary changes. Once you're satisfied, you can select **Keep** on the files individually or in Copilot Chat to accept all changes.
-7. Open the page at [http://localhost:4321][localhost] to see the updates!
-8. Run the Python tests by using `python -m unittest` in the terminal as you did previously.
-9. If any changes are needed, explain the required updates to GitHub Copilot and allow it to generate the new code.
+8. Review the code suggestions to ensure they behave the way you expect them to, making any necessary changes. Once you're satisfied, you can select **Keep** on the files individually or in Copilot Chat to accept all changes.
+9. Open the page at [http://localhost:4321][localhost] to see the updates!
+10. Run the Python tests by using `python -m unittest` in the terminal as you did previously.
+11. If any changes are needed, explain the required updates to GitHub Copilot and allow it to generate the new code.
 
 > [!IMPORTANT]
 > Working iteratively a normal aspect of coding with an AI pair programmer. You can always provide more context to ensure Copilot understands, make additional requests, or rephrase your original prompts.


### PR DESCRIPTION
Update labs to reflect the new way [edit mode](https://code.visualstudio.com/docs/copilot/chat/copilot-edits#_use-edit-mode) is started. It longer has a tab of it's own on the chat window but it now uses a dropdown at the bottom of the chat view.

![image](https://github.com/user-attachments/assets/677cada3-436f-4239-ac8d-5bf59b40b759)
