### PR TITLE
Enable next edit suggestions in settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
         "devcontainer",
         "devcontainers",
         "prebuild"
-    ]
+    ],
+    "github.copilot.nextEditSuggestions.enabled": true,    
 }


### PR DESCRIPTION
Enable next edit suggestions in the settings. Users can benefit from NES without having to explicitly enable it or adding instructions to the workshops for user to enable it.

