### PR TITLE
Update dependabot config to correct path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: /
+    directory: /client
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
This pull request updates the configuration for Dependabot to reflect a change in the directory structure of the project. When the project structure was updated, it looks like the Dependabot config was left expecting the Package json in the root (rather than client directory as it is now).