### PR TITLE
Update CODEOWNERS: add scubaninja, remove peckjon

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # For more information, see [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax)
 
 # This repository is maintained by: 
-* @geektrainer @peckjon @chrisreddington
+* @scubaninja @geektrainer @chrisreddington


### PR DESCRIPTION
Updates CODEOWNERS to reflect current maintainership:

- Added @scubaninja as owner
- Removed @peckjon
- Kept @geektrainer and @chrisreddington

Closes #231