### PR TITLE
Remove @chrisreddington from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # For more information, see [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax)
 
 # This repository is maintained by: 
-* @scubaninja @geektrainer @chrisreddington
+* @scubaninja @geektrainer


### PR DESCRIPTION
Removing `@chrisreddington` to reduce tags in future PRs and reduce noise, having now left GitHub.